### PR TITLE
Fixes #60 ensureVector

### DIFF
--- a/R/ensureVector.R
+++ b/R/ensureVector.R
@@ -8,7 +8,7 @@
 #' @param n [\code{integer(1)}]\cr
 #'   Desired length.
 #'   Default is 1 (the most common case).
-#' @param cl [\code{character}]\cr
+#' @param cl [\code{character}*]\cr
 #'   Only do the operation if \code{x} inherits from this one of these classes,
 #'   otherwise simply let \code{x} pass.
 #'   Default is \code{NULL} which means to always do the operation.

--- a/R/ensureVector.R
+++ b/R/ensureVector.R
@@ -5,31 +5,39 @@
 #'
 #' @param x [any]\cr
 #'   Input element.
-#' @param n [\code{integer}]\cr
+#' @param n [\code{integer(1)}]\cr
 #'   Desired length.
-#' @param cl [\code{character(1)}*]\cr
-#'   Only do the operation if \code{x} inherits from this class, otherwise simply let x pass.
+#'   Default is \code{1} (the most common case).
+#' @param cl [\code{character}*]\cr
+#'   Only do the operation if \code{x} inherits from this one of these classes,
+#'   otherwise simply let \code{x} pass.
 #'   Default is \code{NULL} which means to always do the operation.
 #' @param names [\code{character}*] \cr
 #'   Names for result.
 #'   Default is \code{NULL}, which means no names.
+#' @param ensure.list [\code{logical(1)}]\cr
+#'   Should \code{x} be wrapped in a list in any case?
+#'   Default is \code{FALSE}, i.e., if \code{x} is a scalar value, a vector is
+#'   returned.
 #' @return Ether a vector or list of length \code{n} with replicated \code{x} or \code{x} unchanged..
 #' @export
-ensureVector = function(x, n, cl = NULL, names = NULL) {
+ensureVector = function(x, n = 1L, cl = NULL, names = NULL, ensure.list = FALSE) {
   n = convertInteger(n)
   assertCount(n)
+  assertFlag(ensure.list)
 
   doit = isScalarValue(x) || !is.atomic(x)
   if (!is.null(cl)) {
-    assertString(cl)
+    assertCharacter(cl, min.len = 1L, any.missing = FALSE, all.missing = FALSE)
     doit = doit && inherits(x, cl)
   }
 
   if (doit) {
-    if (isScalarValue(x))
+    if (isScalarValue(x) && !ensure.list) {
       xs = rep(x, n)
-    else
+    } else {
       xs = replicate(n, x, simplify = FALSE)
+    }
 
     if (!is.null(names)) {
       assertCharacter(names, len = n, any.missing = FALSE)

--- a/R/ensureVector.R
+++ b/R/ensureVector.R
@@ -7,8 +7,8 @@
 #'   Input element.
 #' @param n [\code{integer(1)}]\cr
 #'   Desired length.
-#'   Default is \code{1} (the most common case).
-#' @param cl [\code{character}*]\cr
+#'   Default is 1 (the most common case).
+#' @param cl [\code{character}]\cr
 #'   Only do the operation if \code{x} inherits from this one of these classes,
 #'   otherwise simply let \code{x} pass.
 #'   Default is \code{NULL} which means to always do the operation.

--- a/man/ensureVector.Rd
+++ b/man/ensureVector.Rd
@@ -14,7 +14,7 @@ Input element.}
 Desired length.
 Default is 1 (the most common case).}
 
-\item{cl}{[\code{character}]\cr
+\item{cl}{[\code{character}*]\cr
 Only do the operation if \code{x} inherits from this one of these classes,
 otherwise simply let \code{x} pass.
 Default is \code{NULL} which means to always do the operation.}

--- a/man/ensureVector.Rd
+++ b/man/ensureVector.Rd
@@ -12,9 +12,9 @@ Input element.}
 
 \item{n}{[\code{integer(1)}]\cr
 Desired length.
-Default is \code{1} (the most common case).}
+Default is 1 (the most common case).}
 
-\item{cl}{[\code{character}*]\cr
+\item{cl}{[\code{character}]\cr
 Only do the operation if \code{x} inherits from this one of these classes,
 otherwise simply let \code{x} pass.
 Default is \code{NULL} which means to always do the operation.}

--- a/man/ensureVector.Rd
+++ b/man/ensureVector.Rd
@@ -4,22 +4,29 @@
 \alias{ensureVector}
 \title{Blow up single scalars / objects to vectors /  list by replication.}
 \usage{
-ensureVector(x, n, cl = NULL, names = NULL)
+ensureVector(x, n = 1L, cl = NULL, names = NULL, ensure.list = FALSE)
 }
 \arguments{
 \item{x}{[any]\cr
 Input element.}
 
-\item{n}{[\code{integer}]\cr
-Desired length.}
+\item{n}{[\code{integer(1)}]\cr
+Desired length.
+Default is \code{1} (the most common case).}
 
-\item{cl}{[\code{character(1)}*]\cr
-Only do the operation if \code{x} inherits from this class, otherwise simply let x pass.
+\item{cl}{[\code{character}*]\cr
+Only do the operation if \code{x} inherits from this one of these classes,
+otherwise simply let \code{x} pass.
 Default is \code{NULL} which means to always do the operation.}
 
 \item{names}{[\code{character}*] \cr
 Names for result.
 Default is \code{NULL}, which means no names.}
+
+\item{ensure.list}{[\code{logical(1)}]\cr
+Should \code{x} be wrapped in a list in any case?
+Default is \code{FALSE}, i.e., if \code{x} is a scalar value, a vector is
+returned.}
 }
 \value{
 Ether a vector or list of length \code{n} with replicated \code{x} or \code{x} unchanged..

--- a/tests/testthat/test_ensureVector.R
+++ b/tests/testthat/test_ensureVector.R
@@ -1,6 +1,8 @@
 context("ensureVector")
 
 test_that("ensureVector", {
+  # default is n = 1L
+  expect_equal(ensureVector("a"), "a")
   expect_equal(ensureVector("a", n = 2L), c("a", "a"))
   expect_equal(ensureVector("a", n = 2L, cl = "integer"),  "a")
   expect_equal(ensureVector(1, n = 1), c(1))
@@ -12,5 +14,9 @@ test_that("ensureVector", {
   expect_equal(ensureVector(iris, n = 2L, cl = "data.frame"), list(iris, iris))
   expect_equal(ensureVector(iris, n = 2L), list(iris, iris))
   expect_equal(ensureVector(iris, n = 2L, names = c("a", "b")), list(a = iris, b = iris))
+
+  # check ensure.list argument
+  expect_equal(ensureVector("a", ensure.list = TRUE), list("a"))
+  expect_equal(ensureVector(3, n = 3L, ensure.list = TRUE, names = letters[1:3]), list(a = 3, b = 3, c = 3))
 })
 


### PR DESCRIPTION
As discussed with @berndbischl in #60 I did the following changes:

- attribute `cl` can be passed multiple classes and the wrapping is done if `x` inherits from at least one of these classes.
- added flag `ensure.list` which ensures `x` to be wrapped in any case (even if it is a scalar value). The default is `TRUE`.