### PR TITLE
Propose a constant buffer size

### DIFF
--- a/src/itostr.c
+++ b/src/itostr.c
@@ -9,12 +9,12 @@ SEXP itostr (SEXP x, SEXP base) {
     const R_len_t b = INTEGER(base)[0];
     SEXP res = PROTECT(allocVector(STRSXP, n));
 
-    const R_len_t buflen = ceil(log(exp2(64) / log(b)));
-    char buffer[buflen + 1];
-    buffer[buflen] = '\0';
+    // 45 = ceiling(log( 2**64 / log(2)))
+    char buffer[46];
+    buffer[45] = '\0';
 
     for (R_len_t i = 0; i < n; i++) {
-        R_len_t offset = buflen;
+        R_len_t offset = 45;
         int xi = INTEGER(x)[i];
         do {
             buffer[--offset] = base36[xi % b];


### PR DESCRIPTION
I'm not sure if getting the buffer length precisely correct is crucial for this routine (untested), but I notice the buffer is almost always either size 44-45 so why not just pick one & make things easier?

```r
table(buflen = ceiling(log(2**64 / log(2:36))))
# buflen
# 44 45 
# 32  3
```

Came across this because the code fails to compile under the `-Wvla` compiler option. That should be disabled here TBH -- the concern there is getting a stack overflow if the buffer request winds up inordinately large. But in this case the buffer size is very small --> unlikely to cause issues except under _extreme_ memory pressure.

But anyway, we can make things easier on the compiler/etc if we have a constant here which I think should be possible.

To be clear: PR is a suggestion, so feel free to close.